### PR TITLE
[DEV-74] chore: add 30-day dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 30
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 30


### PR DESCRIPTION
Bootstraps dependabot with `cooldown.default-days: 30` on all ecosystems. This delays PRs until a new dependency version has been stable for 30 days, reducing supply-chain risk from fast-moving malicious releases.

Linear: https://linear.app/mixpanel/issue/DEV-74/ensure-all-repos-have-dependabotyml-with-30-day-cooldown